### PR TITLE
Resolve labeler route in scraper blueprint

### DIFF
--- a/tools/photo_labeler.py
+++ b/tools/photo_labeler.py
@@ -25,8 +25,6 @@ from flask import (Flask, jsonify, redirect, render_template_string, request,
 from tools.chat_widget import chatbp
 
 app = Flask(__name__)
-app.register_blueprint(scraperbp)
-app.register_blueprint(chatbp)
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INBOX = REPO_ROOT / "data" / "label_inbox"
 DONE = REPO_ROOT / "data" / "label_done"
@@ -233,6 +231,9 @@ def stats():
         }
     )
 
+
+app.register_blueprint(scraperbp)
+app.register_blueprint(chatbp)
 
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=5004, debug=True)

--- a/tools/scraper_blueprint.py
+++ b/tools/scraper_blueprint.py
@@ -148,7 +148,7 @@ small{color:#666}
     </div>
     <br>
     <button type="submit">Start scraping</button>
-    <a href="{{ url_for('next_image') }}" style="margin-left:12px">Back to Labeler</a>
+    <a href="{{ url_for(labeler_endpoint) }}" style="margin-left:12px">Back to Labeler</a>
     <p><small>Images save to <code>data/label_inbox/</code> as JPG. You can label them immediately.</small></p>
   </form>
 
@@ -156,10 +156,21 @@ small{color:#666}
     <hr>
     <p><b>Scraping '{{ query }}' ...</b></p>
     <p>Saved: {{ saved }} / Errors: {{ errors }}</p>
-    <p><a href="{{ url_for('next_image') }}">Open Labeler</a></p>
+    <p><a href="{{ url_for(labeler_endpoint) }}">Open Labeler</a></p>
   {% endif %}
 </div>
 """
+
+
+def _labeler_endpoint() -> str:
+    """Return a valid endpoint for the image labeler, if available."""
+    for ep in ("photo_labeler.next_image", "next_image", "home"):
+        try:
+            url_for(ep)
+            return ep
+        except Exception:
+            continue
+    return "scraperbp.scrape_ui"
 
 
 @scraperbp.route("/scrape", methods=["GET", "POST"])
@@ -217,6 +228,7 @@ def scrape_ui():
             saved=saved,
             errors=errors,
             query=query,
+            labeler_endpoint=_labeler_endpoint(),
         )
 
     # GET
@@ -229,4 +241,5 @@ def scrape_ui():
         saved=saved,
         errors=errors,
         query="",
+        labeler_endpoint=_labeler_endpoint(),
     )


### PR DESCRIPTION
## Summary
- Dynamically resolve a valid labeler or home endpoint in scraper blueprint instead of hardcoded `next_image`
- Register scraper and chat blueprints in photo_labeler app only after defining routes

## Testing
- `python -m py_compile tools/scraper_blueprint.py`
- `python -m py_compile tools/photo_labeler.py`


------
https://chatgpt.com/codex/tasks/task_e_689ad0ef63848323a2f1fd3ba9fc428e