### PR TITLE
Fix scraper link to labeler endpoint

### DIFF
--- a/tools/scraper_blueprint.py
+++ b/tools/scraper_blueprint.py
@@ -148,7 +148,7 @@ small{color:#666}
     </div>
     <br>
     <button type="submit">Start scraping</button>
-    <a href="{{ url_for('.next_image') }}" style="margin-left:12px">Back to Labeler</a>
+    <a href="{{ url_for('next_image') }}" style="margin-left:12px">Back to Labeler</a>
     <p><small>Images save to <code>data/label_inbox/</code> as JPG. You can label them immediately.</small></p>
   </form>
 
@@ -156,7 +156,7 @@ small{color:#666}
     <hr>
     <p><b>Scraping '{{ query }}' ...</b></p>
     <p>Saved: {{ saved }} / Errors: {{ errors }}</p>
-    <p><a href="{{ url_for('.next_image') }}">Open Labeler</a></p>
+    <p><a href="{{ url_for('next_image') }}">Open Labeler</a></p>
   {% endif %}
 </div>
 """


### PR DESCRIPTION
## Summary
- Fix broken scraper link to the labeler by targeting the correct `next_image` endpoint

## Testing
- `python -m py_compile tools/scraper_blueprint.py`
- `bash -x smoke_test.sh` *(fails: exits early when sample files are missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c0e00f96c83239b8600aa7b5411b7